### PR TITLE
Add an event markdown to template facilitate creation of event

### DIFF
--- a/event-template.md
+++ b/event-template.md
@@ -1,0 +1,8 @@
+## Title of your event
+
+- Begin: dd/mm/yyyy hh:mm UTC+1
+- End: dd/mm/yyyy hh:mm UTC+1
+- Location: https://link-to-visio.org
+- Categories: category 1, category 2
+
+Description of your event.


### PR DESCRIPTION
The markdown file could be copy/pasted and used as a basis to write manually an event for the calendar.