### PR TITLE
github page: upgrade version of github action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare files for GitHub Pages
         run: |
@@ -24,15 +24,15 @@ jobs:
           cp website/calendar.js public/
 
       - name: Deploy to GitHub Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Upload files to GitHub Pages
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: public
 
       - name: Publish GitHub Pages
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 
       - name: Display GitHub Pages URL
         run: |


### PR DESCRIPTION
Solving error

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/`
```